### PR TITLE
fix(LT-5509): Register dlx exchange and queue if configured when crea…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [[tbd]] - 2024-06-04
+
+### Fixed
+- LT-5509: Register dlx exchange and queue if configured when creating a new RabbitMQ subscriber from template.
+
 ## 8.1.0 - 2024-05-30
 
 ### Changed

--- a/src/MarginTrading.BrokerBase/MarginTrading.BrokerBase.csproj
+++ b/src/MarginTrading.BrokerBase/MarginTrading.BrokerBase.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="LykkeBiz.Common.ApiLibrary" Version="4.2.5" />
     <PackageReference Include="LykkeBiz.Logs.MsSql" Version="3.1.0" />
     <PackageReference Include="LykkeBiz.Logs.Serilog" Version="3.3.3" />
-    <PackageReference Include="LykkeBiz.RabbitMqBroker" Version="13.3.1" />
+    <PackageReference Include="LykkeBiz.RabbitMqBroker" Version="13.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.31" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.4.0" />


### PR DESCRIPTION
Register dlx exchange and queue if configured when creating a new RabbitMQ subscriber from template.