### PR TITLE
feat(LT-5509): RabbitMqBroker library version is now a part of connec…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [[tbd]] - 2024-06-07
+
+### Added
+- LT-5509: RabbitMqBroker library version is now a part of connection display name
+
 ## 8.1.1 - 2024-06-04
 
 ### Fixed

--- a/src/MarginTrading.BrokerBase/MarginTrading.BrokerBase.csproj
+++ b/src/MarginTrading.BrokerBase/MarginTrading.BrokerBase.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="LykkeBiz.Common.ApiLibrary" Version="4.2.5" />
     <PackageReference Include="LykkeBiz.Logs.MsSql" Version="3.1.0" />
     <PackageReference Include="LykkeBiz.Logs.Serilog" Version="3.3.3" />
-    <PackageReference Include="LykkeBiz.RabbitMqBroker" Version="13.4.0" />
+    <PackageReference Include="LykkeBiz.RabbitMqBroker" Version="13.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.31" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.4.0" />


### PR DESCRIPTION
RabbitMqBroker library version is now a part of connection display name.